### PR TITLE
Add Kubernetes Showcase and Auto-scaling Demonstration

### DIFF
--- a/backend/orders-service/Dockerfile
+++ b/backend/orders-service/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+# Copy csproj and restore
+COPY ["app.csproj", "./"]
+RUN dotnet restore "app.csproj"
+
+# Copy everything else and build
+COPY . .
+RUN dotnet build "app.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "app.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+EXPOSE 5002
+ENTRYPOINT ["dotnet", "app.dll"]

--- a/backend/users-service/Controllers/UsersController.cs
+++ b/backend/users-service/Controllers/UsersController.cs
@@ -61,4 +61,27 @@ public class UsersController : ControllerBase
             return NotFound(new { Message = $"User with ID {id} not found" });
         return Ok(user);
     }
+
+    /// <summary>
+    /// A synthetic bottleneck endpoint to simulate high CPU load for HPA testing.
+    /// Enabled via ENABLE_BOTTLENECK environment variable.
+    /// </summary>
+    [HttpGet("bottleneck")]
+    public IActionResult Bottleneck([FromQuery] int iterations = 100000000)
+    {
+        var isEnabled = Environment.GetEnvironmentVariable("ENABLE_BOTTLENECK") == "true";
+        if (!isEnabled)
+        {
+            return BadRequest(new { Message = "Bottleneck simulation is not enabled. Set ENABLE_BOTTLENECK=true." });
+        }
+
+        // Perform some CPU intensive work
+        double result = 0;
+        for (int i = 0; i < iterations; i++)
+        {
+            result += Math.Sqrt(i);
+        }
+
+        return Ok(new { Message = "Bottleneck simulation completed", Result = result });
+    }
 }

--- a/backend/users-service/Dockerfile
+++ b/backend/users-service/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+# Copy csproj and restore
+COPY ["app.csproj", "./"]
+RUN dotnet restore "app.csproj"
+
+# Copy everything else and build
+COPY . .
+RUN dotnet build "app.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "app.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+EXPOSE 5001
+ENTRYPOINT ["dotnet", "app.dll"]

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,59 @@
+# Kubernetes Showcase
+
+This directory contains Kubernetes manifests to demonstrate scaling and high availability for the microservices.
+
+## Prerequisites
+
+- A running Kubernetes cluster (e.g., Minikube, Kind, Docker Desktop K8s).
+- `kubectl` installed and configured.
+- Metrics Server installed in the cluster (required for HPA to work).
+
+## Deployment Steps
+
+1. **Build the Docker images:**
+   ```bash
+   docker build -t users-service:latest ./backend/users-service
+   docker build -t orders-service:latest ./backend/orders-service
+   ```
+   *(If using Minikube, run `eval $(minikube docker-env)` before building)*
+
+2. **Deploy the infrastructure (Postgres, Redis, RabbitMQ):**
+   ```bash
+   kubectl apply -f k8s/infrastructure.yaml
+   ```
+
+3. **Deploy the microservices:**
+   ```bash
+   kubectl apply -f k8s/users-service.yaml
+   kubectl apply -f k8s/orders-service.yaml
+   ```
+
+4. **Enable Auto-scaling:**
+   ```bash
+   kubectl apply -f k8s/hpa.yaml
+   ```
+
+## Demonstrating High Load & Scaling
+
+The `users-service` has a synthetic bottleneck endpoint specifically for this showcase.
+
+1. **Monitor the HPA:**
+   ```bash
+   kubectl get hpa users-service-hpa --watch
+   ```
+
+2. **Simulate high load:**
+   In another terminal, port-forward the service:
+   ```bash
+   kubectl port-forward svc/users-service 5001:5001
+   ```
+   Then run a loop to hit the bottleneck endpoint:
+   ```bash
+   while true; do curl "http://localhost:5001/users/bottleneck?iterations=200000000"; done
+   ```
+
+3. **Observe Scaling:**
+   As the CPU usage increases beyond 50%, the HPA will start spinning up more pods (up to 10). You can see this by watching the HPA status or listing pods:
+   ```bash
+   kubectl get pods -l app=users-service -w
+   ```

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: users-service-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: users-service
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50

--- a/k8s/infrastructure.yaml
+++ b/k8s/infrastructure.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init-script
+data:
+  init.sql: |
+    CREATE DATABASE dotnetcv_users;
+    CREATE DATABASE dotnetcv_orders;
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:latest
+        env:
+        - name: POSTGRES_USER
+          value: admin
+        - name: POSTGRES_PASSWORD
+          value: admin
+        - name: POSTGRES_DB
+          value: dotnetcv
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: init-script
+          mountPath: /docker-entrypoint-initdb.d
+      volumes:
+      - name: init-script
+        configMap:
+          name: postgres-init-script
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:latest
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - protocol: TCP
+      port: 6379
+      targetPort: 6379
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+      - name: rabbitmq
+        image: rabbitmq:3-management
+        ports:
+        - containerPort: 5672
+        - containerPort: 15672
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+spec:
+  selector:
+    app: rabbitmq
+  ports:
+    - name: amqp
+      protocol: TCP
+      port: 5672
+      targetPort: 5672
+    - name: management
+      protocol: TCP
+      port: 15672
+      targetPort: 15672

--- a/k8s/orders-service.yaml
+++ b/k8s/orders-service.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orders-service
+  labels:
+    app: orders-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: orders-service
+  template:
+    metadata:
+      labels:
+        app: orders-service
+    spec:
+      containers:
+      - name: orders-service
+        image: orders-service:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5002
+        env:
+        - name: ASPNETCORE_ENVIRONMENT
+          value: Development
+        - name: ASPNETCORE_URLS
+          value: http://+:5002
+        - name: ConnectionStrings__DefaultConnection
+          value: Host=postgres;Database=dotnetcv_orders;Username=admin;Password=admin
+        - name: ConnectionStrings__Redis
+          value: redis:6379
+        - name: ConnectionStrings__RabbitMQ
+          value: amqp://guest:guest@rabbitmq:5672/
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 5002
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 5002
+          initialDelaySeconds: 15
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: orders-service
+spec:
+  selector:
+    app: orders-service
+  ports:
+    - protocol: TCP
+      port: 5002
+      targetPort: 5002
+  type: ClusterIP

--- a/k8s/users-service.yaml
+++ b/k8s/users-service.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: users-service
+  labels:
+    app: users-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: users-service
+  template:
+    metadata:
+      labels:
+        app: users-service
+    spec:
+      containers:
+      - name: users-service
+        image: users-service:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 5001
+        env:
+        - name: ASPNETCORE_ENVIRONMENT
+          value: Development
+        - name: ASPNETCORE_URLS
+          value: http://+:5001
+        - name: ConnectionStrings__DefaultConnection
+          value: Host=postgres;Database=dotnetcv_users;Username=admin;Password=admin
+        - name: ConnectionStrings__Redis
+          value: redis:6379
+        - name: ConnectionStrings__RabbitMQ
+          value: amqp://guest:guest@rabbitmq:5672/
+        - name: ENABLE_BOTTLENECK
+          value: "true"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 5001
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 5001
+          initialDelaySeconds: 15
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: users-service
+spec:
+  selector:
+    app: users-service
+  ports:
+    - protocol: TCP
+      port: 5001
+      targetPort: 5001
+  type: ClusterIP


### PR DESCRIPTION
This PR adds a Kubernetes showcase to the project. It includes:
1. A new `bottleneck` endpoint in the `users-service` that can be enabled via the `ENABLE_BOTTLENECK` environment variable. This endpoint performs CPU-intensive work to simulate high load.
2. Dockerfiles for both .NET microservices (`users-service` and `orders-service`).
3. Kubernetes manifests in a new `k8s/` directory, including:
   - `users-service.yaml`: Deployment and Service for the users service.
   - `orders-service.yaml`: Deployment and Service for the orders service.
   - `infrastructure.yaml`: Deployments and Services for PostgreSQL, Redis, and RabbitMQ.
   - `hpa.yaml`: HorizontalPodAutoscaler configuration for the users-service.
4. A comprehensive `k8s/README.md` explaining how to build images, deploy the manifests, and demonstrate auto-scaling using the bottleneck endpoint.

---
*PR created automatically by Jules for task [745614699377837046](https://jules.google.com/task/745614699377837046) started by @aslepenkov*